### PR TITLE
fix toLower is not understood

### DIFF
--- a/Classes/PersistentMainFX.sc
+++ b/Classes/PersistentMainFX.sc
@@ -90,7 +90,7 @@ PersistentMainFX {
   }
 
   *addSynthDef{
-    synthdefName = (this.name.toLower.asString ++ numChans).asSymbol;
+    synthdefName = (this.name.asString.toLower ++ numChans).asSymbol;
 
     SynthDef.new(synthdefName, this.synthFunc()).add;
 


### PR DESCRIPTION
Hi,

It seems I got error `toLower` is not understood when I try to create new instance I inherit from PersistentMainFX.
Currently I fix this by overriding `addSynthDef` but it would be nice if I can only override syncFunc.
The problem is `this.name` is Symbol, so convert to string first and then use toLower will fix the bug.

Regards,